### PR TITLE
GH Actions: Run flake8-print & flake8-todo extensions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,10 +45,11 @@ jobs:
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
 
+    - name: Check the code formatting
+      run: |
+        black . --diff
+
     - name: Check the code for errors
       run: |
         flake8 . --count --statistics
-
-    - name: Run Black
-      run: |
-        black . --diff
+        flake8 . --select=T --show-source --exit-zero


### PR DESCRIPTION
I'm adding one more step to the Actions build. It's only calling `flake8`'s extensions for detecting `print()`s and `TODO`s so they are easily accesible.