### PR TITLE
Requirements fixed + Logs bugfix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ discord.py>=1.5.0
 gitpython>=3.1.8
 psycopg2-binary>=2.8.6
 python-json-logger>=2.0.1
+requests>=2.25.1
 sqlalchemy>=1.3.19


### PR DESCRIPTION
Bot build in docker container was failing so I added the required package.

Logs had a bug where the next rollover time was not computed so rollovers were happening constantly after the first one. I didn't realize it needs to be computed during execution of the doRollover() method. Added that functionality.