### PR TITLE
Add dynamic database file loading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,5 +55,5 @@ jobs:
 
       - name: Run pytest
         run: |
-          DB_STRING=sqlite:///test.db TOKEN=0 python3 pumpkin.py --create-database
+          DB_STRING=sqlite:///test.db python3 -c "import database; database.init_core(); database.init_modules();"
           DB_STRING=sqlite:///test.db pytest -v tests/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ from core import text, utils
 
 
 logging.config.fileConfig("core/log.conf")
-logger = logging.getLogger("pumpkin_log")
+logger = logging.getLogger("pumpkin")
 
 tr = text.Translator(__file__).translate
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,6 @@ from discord.ext import commands
 from core import text, utils
 
 
-logging.config.fileConfig("core/log.conf")
 logger = logging.getLogger("pumpkin")
 
 tr = text.Translator(__file__).translate

--- a/core/log.conf
+++ b/core/log.conf
@@ -1,14 +1,14 @@
 [loggers]
-keys = root,pumpkin_log
+keys = root,pumpkin
 
 [logger_root]
 handlers =
 
-[logger_pumpkin_log]
+[logger_pumpkin]
 level = DEBUG
 handlers = file,stream
 propagate=0
-qualname = pumpkin_log
+qualname = pumpkin
 
 [handlers]
 keys = stream,file

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -7,7 +7,8 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-logger = logging.getLogger("pumpkin_log")
+logging.config.fileConfig("core/log.conf")
+logger = logging.getLogger("pumpkin")
 
 
 class Database:

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -41,9 +41,6 @@ def _list_directory_directories(directory: str) -> List[str]:
 
 def _import_database_tables():
     """Import database tables from the "modules/" directory."""
-    # Guarantee all finders will notice new modules.
-    importlib.invalidate_caches()
-
     repositories: List[str] = _list_directory_directories("modules")
     for repository in repositories:
         modules: List[str] = _list_directory_directories(repository)
@@ -67,8 +64,18 @@ def _import_database_tables():
                 logger.error(f"Could not import database models in {import_stub}: {exc}.")
 
 
-def initiate():
+def init_core():
+    """Load core models and create their tables."""
+    # Import core tables
+    importlib.import_module("database.config")
+
+    database.base.metadata.create_all(database.db)
+    session.commit()
+
+
+def init_modules():
     """Load all database models and create their tables."""
+    # Find and import module tables
     _import_database_tables()
 
     database.base.metadata.create_all(database.db)

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -7,7 +7,6 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-logging.config.fileConfig("core/log.conf")
 logger = logging.getLogger("pumpkin")
 
 

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -1,8 +1,13 @@
 import os
+import importlib
+import logging
+from typing import List
 
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
+logger = logging.getLogger("pumpkin_log")
 
 
 class Database:
@@ -13,3 +18,57 @@ class Database:
 
 database = Database()
 session = sessionmaker(database.db)()
+
+
+def _list_directory_directories(directory: str) -> List[str]:
+    """Return filtered list of directories.
+
+    :param directory: Absolute or relative (from the __main__ file) path to the
+        directory.
+    :returns: List of paths to directories inside the requested directory.
+        Directories starting with underscore (e.g. __pycache__) are not
+        included.
+    """
+    if not os.path.isdir(directory):
+        raise ValueError(f"{directory} is not a directory.")
+
+    all_files = os.listdir(directory)
+    filenames = [f for f in all_files if not f.startswith("_")]
+    files = [os.path.join(directory, d) for d in filenames]
+    return [d for d in files if os.path.isdir(d)]
+
+
+def _import_database_tables():
+    """Import database tables from the "modules/" directory."""
+    # Guarantee all finders will notice new modules.
+    importlib.invalidate_caches()
+
+    repositories: List[str] = _list_directory_directories("modules")
+    for repository in repositories:
+        modules: List[str] = _list_directory_directories(repository)
+        for module in modules:
+            # Detect module's database files
+            # TODO This has not been tested with "database/" as directory.
+            # 1/ Do we need that functionality?
+            # 2/ Do we want to support this? It may be solved just by importing the modules
+            #    to the "database/__init__.py" file.
+            database_stub: str = os.path.join(module, "database")
+            if not os.path.isfile(database_stub + ".py") and not os.path.isdir(database_stub):
+                continue
+
+            # Import the module
+            try:
+                import_stub: str = database_stub.replace("/", ".")
+                importlib.import_module(import_stub)
+                logger.debug(f"Imported database models in {import_stub}.")
+            except ModuleNotFoundError as exc:
+                # TODO How to properly log errors?
+                logger.error(f"Could not import database models in {import_stub}: {exc}.")
+
+
+def initiate():
+    """Load all database models and create their tables."""
+    _import_database_tables()
+
+    database.base.metadata.create_all(database.db)
+    session.commit()

--- a/database/config.py
+++ b/database/config.py
@@ -5,6 +5,8 @@ from database import session
 
 
 class Config(database.base):
+    """Global bot configuration."""
+
     __tablename__ = "config"
 
     idx = Column(Integer, primary_key=True, autoincrement=True)
@@ -16,6 +18,7 @@ class Config(database.base):
 
     @staticmethod
     def get():
+        """Get instance of global bot settings. If there is none, it will be created."""
         query = session.query(Config).one_or_none()
         if query is None:
             query = Config()
@@ -24,6 +27,7 @@ class Config(database.base):
         return query
 
     def save(self):
+        """Save global settings."""
         session.merge(self)
         session.commit()
         return

--- a/database/info.txt
+++ b/database/info.txt
@@ -1,1 +1,0 @@
-Core database logic. Dynamically loading database files from cogs, core bot config database entries.

--- a/modules/base/admin/__init__.py
+++ b/modules/base/admin/__init__.py
@@ -18,7 +18,6 @@ from database import config as configfile
 tr = text.Translator(__file__).translate
 config = configfile.Config.get()
 
-logging.config.fileConfig("core/log.conf")
 logger = logging.getLogger("pumpkin")
 
 

--- a/modules/base/admin/__init__.py
+++ b/modules/base/admin/__init__.py
@@ -17,7 +17,9 @@ from database import config as configfile
 
 tr = text.Translator(__file__).translate
 config = configfile.Config.get()
-logger = logging.getLogger("pumpkin_log")
+
+logging.config.fileConfig("core/log.conf")
+logger = logging.getLogger("pumpkin")
 
 
 class Repository:

--- a/modules/base/base/__init__.py
+++ b/modules/base/base/__init__.py
@@ -10,7 +10,6 @@ from .database import BaseBasePin as Pin
 
 tr = text.Translator(__file__).translate
 
-logging.config.fileConfig("core/log.conf")
 logger = logging.getLogger("pumpkin")
 
 
@@ -70,6 +69,7 @@ class Base(commands.Cog):
             # remove if the message is pinned or is in unpinnable channel
             # TODO Unpinnable channels
             if message.pinned or False:
+                logger.debug(f"Removing {payload.user_id}'s pin: Message is already pinned.")
                 await reaction.clear()
                 return
 
@@ -80,6 +80,13 @@ class Base(commands.Cog):
             # TODO Log members that pinned the message
             try:
                 await message.pin()
+                logger.info(
+                    "Pinning message {0.id} in #{1.name} ({1.id}) in {2.name} ({2.id}).".format(
+                        message,
+                        message.channel,
+                        message.guild,
+                    )
+                )
             except discord.errors.HTTPException as exc:
                 logger.error(f"Could not pin message: {exc}.")
                 return

--- a/modules/base/base/database.py
+++ b/modules/base/base/database.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, Integer, BigInteger
+
+from database import database, session
+
+
+class BaseBasePin(database.base):
+    __tablename__ = "base_base_pin"
+    __table_args__ = {"extend_existing": True}
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    guild_id = Column(BigInteger, unique=True)
+    limit = Column(Integer, default=5)
+
+    @staticmethod
+    def get(guild_id: int):
+        """Get userpin preferences for the guild."""
+        query = session.query(BaseBasePin).filter(BaseBasePin.guild_id == guild_id).one_or_none()
+        if query is None:
+            query = BaseBasePin(guild_id=guild_id)
+            session.add(query)
+            session.commit()
+        return query
+
+    def __repr__(self):
+        return f'<BaseBasePin guild_id="{self.guild_id}" limit="{self.limit}">'

--- a/modules/base/errors/__init__.py
+++ b/modules/base/errors/__init__.py
@@ -9,7 +9,6 @@ import core.exceptions
 from core import text, utils
 
 
-logging.config.fileConfig("core/log.conf")
 logger = logging.getLogger("pumpkin")
 
 tr = text.Translator(__file__).translate

--- a/modules/base/errors/__init__.py
+++ b/modules/base/errors/__init__.py
@@ -10,7 +10,7 @@ from core import text, utils
 
 
 logging.config.fileConfig("core/log.conf")
-logger = logging.getLogger("pumpkin_log")
+logger = logging.getLogger("pumpkin")
 
 tr = text.Translator(__file__).translate
 

--- a/pumpkin.py
+++ b/pumpkin.py
@@ -81,7 +81,7 @@ if not os.path.exists("logs/"):
     os.mkdir("logs/")
 
 logging.config.fileConfig("core/log.conf")
-logger = logging.getLogger("pumpkin_log")
+logger = logging.getLogger("pumpkin")
 
 
 # Setup listeners

--- a/pumpkin.py
+++ b/pumpkin.py
@@ -36,7 +36,8 @@ del root_path
 # Database
 
 
-database.initiate()
+database.init_core()
+database.init_modules()
 
 
 # Load or create config object

--- a/pumpkin.py
+++ b/pumpkin.py
@@ -1,4 +1,3 @@
-import argparse
 import os
 import sys
 import logging
@@ -34,44 +33,16 @@ os.chdir(root_path)
 del root_path
 
 
-# Parser arguments
+# Database
 
 
-def database_init(drop: bool = None) -> None:
-    if drop:
-        print("Wiping database...")
-        database.database.base.metadata.drop_all(database.database.db)
-    database.database.base.metadata.create_all(database.database.db)
-    database.session.commit()
-
-
-argparser = argparse.ArgumentParser(prog="pumpkin.py")
-argparser.add_argument(
-    "--wipe-database",
-    help="drop the database tables",
-    action="store_true",
-)
-argparser.add_argument(
-    "--create-database",
-    help="create the database and exit",
-    action="store_true",
-)
-args = argparser.parse_args()
-
-database_init(drop=args.wipe_database)
+database.initiate()
 
 
 # Load or create config object
 
 
 config = database.config.Config.get()
-
-
-# Stop the execution if we're doing something else
-
-
-if __name__ != "__main__" or args.create_database:
-    sys.exit(0)
 
 
 # Setup discord.py
@@ -90,8 +61,7 @@ def _prefix_callable(bot, message) -> str:
     return base
 
 
-intents = discord.Intents.default()
-intents.members = True
+intents = discord.Intents.all()
 
 from core import utils
 from core.help import Help

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -6,3 +6,7 @@ def test_language_files():
     assert None is Module("modules/base/admin/").result
     assert None is Module("modules/base/base/").result
     assert None is Module("modules/base/errors/").result
+
+
+# TODO Test substitutions
+# TODO Test database stuff


### PR DESCRIPTION
The `database.initiate()` imports all classes from `modules/<repo>/<module>/database.py` and creates their tables.

There is some issue with this current implementation -- when the module is reloaded, an exception is thrown:
```
This declarative base already contains a class with the same class name
and module name as modules.base.base.database.BaseBasePin, and will be
replaced in the string-lookup table.
```

When `__table_args__ = {"extend_existing": True}` is added to the model definition, only warning is logged, but it works as nothing is thrown. This is rather a workaround than a solution, it should be investigated more.