### PR TITLE
Docs: Add information about the bot/framework development

### DIFF
--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -1,66 +1,10 @@
-.. currentmodule:: .
-
 Development
 ===========
 
-Short snippets on how to write the bot.
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
 
-How to log errors
------------------
-
-.. code-block:: python
-	:linenos:
-
-	try:
-		await ctx.channel.fetch_message(0)
-	except discord.exceptions.HTTPException:
-		await guild_log(
-			ctx.author,
-			ctx.channel,
-			"Could not fetch message",
-			exception=exc,
-		)
-
-Translations
-------------
-
-If the string represents bot's reply, it should end with a period. If the string is part of embed content, it should not have a period. If it is command help, it should not have a period.
-
-.. code-block:: ini
-	:linenos:
-
-	[language get]
-	help = Localisation info
-	title = Localisation
-	user = User settings
-	guild = Server settings
-	bot = Global settings
-	not set = Not set
-
-	[language set]
-	help = Change preferred language
-	bad language = I can't speak that language.
-	reply = I'll remember the preference of **((language))**.
-
-If the context isn't available (e.g. in raw reaction), you can construct the :class:`core.TranslationContext`.
-
-.. code-block:: python
-	:linenos:
-
-	from core import TranslationContext
-
-	...
-
-	@commands.Cog.listener()
-	async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
-		tc = TranslationContext(payload.guild_id, payload.user_id)
-
-		message = await utils.Discord.get_message(
-			self.bot,
-			payload.guild_id,
-			payload.channel_id,
-			payload.message_id,
-		)
-		await message.reply("foo", "bar", tc)
-
-If you omit it, the bot will use its global language settings instead of user/guild preference.
+   repository
+   logging
+   translations

--- a/docs/development/logging.rst
+++ b/docs/development/logging.rst
@@ -1,0 +1,29 @@
+Logging
+=======
+
+There are two log targets: the bot one and a guild one. You, as a developer, will most likely be using the Guild logger -- all the logs send to it will be contained only in the guild (and the hosting server); the Bot logs are distributed to all guilds the pumpkin.py instance is connected to.
+
+The logger targets are usually defined on top of the file:
+
+.. code-block:: python3
+
+	from core import logging
+
+	bot_log = logging.Bot.logger()
+	guild_log = logging.Guild.logger()
+
+And to use the logger, use
+
+.. code-block:: python
+
+	try:
+	    await action_that_throws_error()
+	except discord.exceptions.HTTPException:
+	    await guild_log(
+	        ctx.author,
+	        ctx.channel,
+	        "Could not do the action.",
+	        exception=exc,
+	    )
+
+Please note that because the logs may be sent to the logging channels on Discord, they have to be ``await``\ ed.

--- a/docs/development/repository.rst
+++ b/docs/development/repository.rst
@@ -1,0 +1,178 @@
+Creating a repository
+=====================
+
+.. warning::
+
+	The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in `RFC 2119 <https://tools.ietf.org/html/rfc2119>`_.
+
+Let's write a simple repository with just one module. We're gonna name it ``bistro``, because we'll gonna be making some delicious snacks.
+
+You can start with an empty directory (named ``pumpkin-bistro``, for example), or you can use our `template repository <https://github.com/Pumpkin-py/pumpkin-template>`_, it doesn't matter.
+
+Repository metadata
+-------------------
+
+The first file we're gonna create will be ``__init__.py``. This file MUST be present in your repository, because pumpkin.py reads its information in order to work with it. It has to contain three variables described below´:
+
+- ``__name__`` is a string representing name of the repository. It must be instance-unique and can only contain lowercase ASCII letters and a dash (``[a-z-]+``) and MUST NOT be ``core`` or ``base``. Moderators can run the **repository list** command to show installed repositories to prevent name clashes.
+- ``__version__`` is a string that MUST follow the `semver rules <https://semver.org/>`_.
+- ``__all__`` is a tuple of strings that lists all modules included in the repository.
+
+In our case, the file might look like this:
+
+.. code-block:: python3
+
+	__name__ = "bistro"
+	__version__ = "0.0.1"
+	__all__ = ("bistro", )
+
+Next file that SHOULD be present in your repository is ``README.md`` or ``README.rst``. This file should contain the information about the repository and its modules. It should also link to the pumpkin.py project, so the visitors aren't confused about the meaning of it.
+
+Our README may start like this:
+
+.. code-block:: markdown
+
+	# Bistro
+
+	An unofficial [pumpkin.py](https://github.com/pumpkin-py) extension.
+
+	The module allows you to ...
+
+The last metadata file is ``CHANGELOG.rst``, which SHOULD be present in your repository. For each version you create you MUST add a second-level heading with a version number and a text content, which SHOULD be a list of points describing the changes in the version.
+
+.. code-block:: rst
+
+	CHANGELOG
+	=========
+
+	Unreleased
+	----------
+	- Fix for #14: Don't allow infinite cakes
+
+	0.0.2
+	-----
+	- Add dynamic prices
+	- Add option to close the bistro
+
+	0.0.1
+	-----
+	- Initial release
+
+Resource files
+--------------
+
+``requiremens.txt`` MAY be present in the repository. If found, the pumpkin.py instance will use standard tools to install packages from this file. You MUST NOT add packages your modules do not require.
+
+.. note::
+
+	Use ``requiremens-dev.txt`` for development packages.
+
+The module
+----------
+
+For each module that has been specified in the init's ``__all__`` variable there must exist a directory with the same name at the root of the repository. And each module has to have a ``module.py`` file inside of its directory.
+
+In our case, we only have one module specified, so we have to create a file ``bistro/module.py``. This file has to contain the class inheriting from discord.py's Cog and the ``setup()`` function to load the module.
+
+.. code-block:: python3
+
+	import discord
+	from discord.ext import commands
+
+	from core import acl, text, logging
+
+	tr = text.Translator(__file__).translate
+	bot_log = logging.Bot.logger()
+	guild_log = logging.Guild.logger()
+
+
+	class Bistro(commands.Cog):
+		def __init__(self, bot):
+			self.bot = bot
+
+		...
+
+	def setup(bot) -> None:
+		bot.add_cog(Bistro(bot))
+
+.. note::
+
+	See subarticles on logging and text translation.
+
+Module database
+---------------
+
+When the module uses database in any way, the SQLAlchemy tables MUST be placed in ``<module>/database.py``.
+
+How the table class is named is up to you; the ``__tablename__`` property SHOULD be named ``<repository>_<module>_<functionality>``. Each entry SHOULD have primary index column named ``idx``. Each table SHOULD have a ``guild_id`` column, unless you have reason not to do otherwise -- so the data from multiple guilds don't clash together.
+
+Channel column SHOULD be named ``channel_id``, message column SHOULD be named ``message_id``, user/member column SHOULD be named ``user_id`` -- unless there is a situation where this is not applicable (e.g. two user colums).
+
+All database tables SHOULD have a ``__repr__`` representation and SHOULD have a ``dump`` function returning a dictionary. Database operations (``get``, ``add``, ``remove``) SHOULD be implemented as ``@staticmethod``\ s.
+
+.. note::
+
+	Always use ``remove()`` over ``delete()``, for consinstency reasons.
+
+An example database file ``bistro/database.py`` may look like this:
+
+.. code-block:: python3
+
+	from __future__ import annotations
+	from typing import Optional
+
+	from sqlalchemy import Column, Integer, BigInteger, String
+
+	from database import database, session
+
+	class Item(database.base):
+	    __tablename__ = "bistro_bistro_item"
+
+	    idx = Column(Integer, primary_key=True)
+	    guild_id = Column(BigInteger)
+	    name = Column(String)
+	    description = Column(String)
+
+	    @staticmethod
+	    def add(guild_id: int, name: str, description: str) -> Item:
+	        query = Item(
+	            guild_id=guild_id,
+	            name=name,
+	            description=description
+	        )
+	        session.add(query)
+	        session.commit()
+	        return query
+
+	    @staticmethod
+	    def get(guild_id: int, name: str) -> Optional[Item]:
+	        query = session.query(Item).filter_by(
+	            guild_id=guild_id,
+	            name=name,
+	        ).one_or_none()
+	        return query
+
+	    @staticmethod
+	    def remove(guild_id: int, name: str) -> int:
+	        query = session.query(Item).filter_by(
+	            guild_id=guild_id,
+	            name=name,
+	        ).delete()
+	        return query
+
+	    def save(self):
+	        session.commit()
+
+	    def __repr__(self) -> str:
+	        return (
+	            f'<Item idx="{self.idx}" '
+	            f'guild_id="{self.guild_id}" name="{self.name}" '
+	            f'description="{self.description}">'
+	        )
+
+	    def dump(self) -> dict:
+	    	return {
+	    	    "guild_id": self.guild_id,
+	    	    "name": self.name,
+	    	    "description": self.description,
+	    	}

--- a/docs/development/translations.rst
+++ b/docs/development/translations.rst
@@ -1,0 +1,71 @@
+Translations
+============
+
+There are four **if**\ s of the text format:
+
+- If the string represents bot's reply, it should end with a period.
+- If the string is part of embed content, it should not end with a period.
+- If it is command help, it should not end with a period.
+- If the embed content or help is one or more sentences, it should end with a period.
+
+The language files are stored in module's ``lang`` directory as ini files. Each module MUST have an ``en.ini`` and MAY have additional languages. When they aren't found, the english string is used.
+
+.. code-block:: ini
+
+	...
+
+	[language get]
+	help = Localisation info
+	title = Localisation
+	user = User settings
+	guild = Server settings
+	bot = Global settings
+	not set = Not set
+
+	[language set]
+	help = Change preferred language
+	bad language = I can't speak that language.
+	reply = I'll remember the preference of **((language))**.
+
+All modules define the translation function on top of the file, and you should too:
+
+.. code-block:: python3
+
+	from core import text
+
+	tr = text.Translator(__file__).translate
+
+	...
+
+Because the members and guilds can set their language preference we have to tell the translation function the source of the context, so it can pick the right language. We do this by using the ``Context`` discord.py supplies with every command call:
+
+.. code-block:: python3
+
+	async def language_set(self, ctx, language: str):
+	    if language not in ("en", "es"):
+	        await ctx.reply(tr("language set", "bad language", ctx))
+	        return
+
+	    ...
+
+Sometimes context isn't available, though -- e.g. in raw reaction. These times you can construct the :class:`core.TranslationContext`.
+
+.. code-block:: python
+
+	from core import TranslationContext
+
+	...
+
+	@commands.Cog.listener()
+	async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+	    tc = TranslationContext(payload.guild_id, payload.user_id)
+
+	    message = await utils.Discord.get_message(
+	        self.bot,
+	        payload.guild_id,
+	        payload.channel_id,
+	        payload.message_id,
+	    )
+	    await message.reply("foo", "bar", tc)
+
+If you omit it, the bot will use its global language settings instead of user/guild preference.

--- a/docs/getting-started/index.rst
+++ b/docs/getting-started/index.rst
@@ -1,7 +1,29 @@
-Gettnig started
+Getting started
 ===============
 
 or How to setup the server.
 
-* ACL
-* autpin, autothread, bookmarks
+It is possible not to add the **Administrator** permission to the bot, and try to add only the neccessary permissions, or by trial and error. However, non-admin setup is not officially supported and there is no guarantee that newly required permissions will be announced.
+
+The bot also assumes that you've enabled both privileged intents: Members and Presences.
+
+Permissions
+-----------
+
+ACL is one of first things you want to setup.
+
+TODO
+
+Utility functions
+-----------------
+
+autpin, autothread, bookmarks
+
+TODO
+
+Verification
+------------
+
+Verification module
+
+TODO

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,10 +11,10 @@ Intro to pumpkin.py
    :caption: Contents:
 
    installation/index
-   changelog
    getting-started/index
    development/index
    legal
+   changelog
    autoapi/index
 
 

--- a/docs/installation/03-config.rst
+++ b/docs/installation/03-config.rst
@@ -9,7 +9,7 @@ Connecting to remote server by using username and password gets annoying really 
 .. code-block:: bash
 
 	ssh-keygen -t ed25519
-	# save the file as something descriptive, e.g. /home/discord/.ssh/pumpkin_server
+	# save the file as something descriptive, e.g. /home/<username>/.ssh/pumpkin_server
 	# you can omit the password by pressing Enter twice
 
 Then add the key to the SSH configuration file (``~/.ssh/config``), so it knows when to use it.
@@ -21,6 +21,8 @@ Then add the key to the SSH configuration file (``~/.ssh/config``), so it knows 
 		PubkeyAuthentication yes
 		IdentitiesOnly yes
 		IdentityFile ~/.ssh/pumpkin_server
+
+To use the SSH key on the server, you have to add the contents of the **public** key (e.g. ``/home/<username>/.ssh/pumpkin_server.pub``) to server's ``/home/discord/.ssh/authorized_keys``.
 
 PostgreSQL backups
 ------------------

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-This chapter will guide you through the setup process.
+This chapter will guide you through the setup process. You can pick either the docker or direct installation, they touch the same topic and are independent of each other.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Some of the information (mainly on 3rd party repositories) contain information that has not yet been merged: currently the modules are directly inside of the `modules/` directory, but they will have to be moved one layer deeper to allow us to add tests and another helper scripts or data.