### PR TITLE
Maintenance

### DIFF
--- a/database/acl.py
+++ b/database/acl.py
@@ -37,7 +37,7 @@ class ACL_group(database.base):
     # function. In this case we should use 'parent_name'/'parent_id' and the
     # 'parent' attribute should be the parent object.
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    idx = Column(Integer, primary_key=True, autoincrement=True)
     guild_id = Column(BigInteger)
     name = Column(String)
     parent = Column(String, default=None)
@@ -46,7 +46,7 @@ class ACL_group(database.base):
 
     def __repr__(self) -> str:
         return (
-            f'<ACL_group id="{self.id}" name="{self.name}" parent="{self.parent}" '
+            f'<ACL_group idx="{self.idx}" name="{self.name}" parent="{self.parent}" '
             f'guild_id="{self.guild_id}" role_id="{self.role_id}">'
         )
 
@@ -166,7 +166,7 @@ class ACL_rule(database.base):
 
     __tablename__ = "acl_rules"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    idx = Column(Integer, primary_key=True, autoincrement=True)
     guild_id = Column(BigInteger)
     command = Column(String)
     default = Column(Boolean, default=False)
@@ -175,7 +175,7 @@ class ACL_rule(database.base):
 
     def __repr__(self) -> str:
         return (
-            f'<ACL_rule id="{self.id}" guild_id="{self.guild_id}" '
+            f'<ACL_rule idx="{self.idx}" guild_id="{self.guild_id}" '
             f'command="{self.command}" default="{self.default}">'
         )
 
@@ -189,7 +189,6 @@ class ACL_rule(database.base):
     def dump(self) -> Dict[str, Union[int, str, List[Union[int, str]]]]:
         """Return object representation as dictionary for easy serialisation."""
         return {
-            "id": self.id,
             "guild_id": self.guild_id,
             "command": self.command,
             "default": self.default,
@@ -283,7 +282,7 @@ class ACL_rule(database.base):
         if group is None:
             raise ValueError(f'group_name="{group_name}" cannot be mapped to group.')
 
-        rule_group = ACL_rule_group(group_id=group.id, allow=allow)
+        rule_group = ACL_rule_group(group_idx=group.idx, allow=allow)
         self.groups.append(rule_group)
         session.commit()
         return rule_group
@@ -313,7 +312,7 @@ class ACL_rule(database.base):
         :param allow: Whether to allow or deny the permission to given user.
         :return: Rule user constraint.
         """
-        rule_user = ACL_rule_user(rule_id=self.id, user_id=user_id, allow=allow)
+        rule_user = ACL_rule_user(rule_idx=self.idx, user_id=user_id, allow=allow)
         self.users.append(rule_user)
         session.commit()
         return rule_user
@@ -344,31 +343,30 @@ class ACL_rule_user(database.base):
 
     __tablename__ = "acl_rule_users"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    rule_id = Column(Integer, ForeignKey("acl_rules.id", ondelete="CASCADE"))
+    idx = Column(Integer, primary_key=True, autoincrement=True)
+    rule_idx = Column(Integer, ForeignKey("acl_rules.idx", ondelete="CASCADE"))
     rule = relationship("ACL_rule", back_populates="users")
     user_id = Column(BigInteger)
     allow = Column(Boolean)
 
     def __repr__(self) -> str:
         return (
-            f'<ACL_rule_user id="{self.id}" '
-            f'rule_id="{self.rule_id}" user_id="{self.user_id}" '
+            f'<ACL_rule_user idx="{self.idx}" '
+            f'rule_idx="{self.rule_id}" user_id="{self.user_id}" '
             f'allow="{self.allow}">'
         )
 
     def __eq__(self, obj) -> bool:
         return (
             type(self) == type(obj)
-            and self.rule_id == obj.rule_id
+            and self.rule_idx == obj.rule_idx
             and self.user_id == obj.user_id
         )
 
     def dump(self) -> Dict[str, Union[bool, int]]:
         """Return object representation as dictionary for easy serialisation."""
         return {
-            "id": self.id,
-            "rule_id": self.rule_id,
+            "rule_idx": self.rule_id,
             "user_id": self.user_id,
             "allow": self.allow,
         }
@@ -382,32 +380,31 @@ class ACL_rule_group(database.base):
 
     __tablename__ = "acl_rule_groups"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    rule_id = Column(Integer, ForeignKey("acl_rules.id", ondelete="CASCADE"))
+    idx = Column(Integer, primary_key=True, autoincrement=True)
+    rule_idx = Column(Integer, ForeignKey("acl_rules.idx", ondelete="CASCADE"))
     rule = relationship("ACL_rule", back_populates="groups")
-    group_id = Column(Integer, ForeignKey("acl_groups.id", ondelete="CASCADE"))
+    group_idx = Column(Integer, ForeignKey("acl_groups.idx", ondelete="CASCADE"))
     group = relationship("ACL_group", back_populates="rules")
     allow = Column(Boolean, default=None)
 
     def __repr__(self) -> str:
         return (
-            f'<ACL_rule_group id="{self.id}" '
-            f'rule_id="{self.rule_id}" group_id="{self.group_id}" '
+            f'<ACL_rule_group idx="{self.idx}" '
+            f'rule_idx="{self.rule_id}" group_idx="{self.group_id}" '
             f'allow="{self.allow}">'
         )
 
     def __eq__(self, obj) -> bool:
         return (
             type(self) == type(obj)
-            and self.rule_id == obj.rule_id
-            and self.group_id == obj.group_id
+            and self.rule_idx == obj.rule_idx
+            and self.group_idx == obj.group_idx
         )
 
     def dump(self) -> Dict[str, Union[bool, int]]:
         """Return object representation as dictionary for easy serialisation."""
         return {
-            "id": self.id,
-            "rule_id": self.rule_id,
-            "group_id": self.group_id,
+            "rule_idx": self.rule_id,
+            "group_idx": self.group_id,
             "allow": self.allow,
         }

--- a/database/language.py
+++ b/database/language.py
@@ -17,13 +17,13 @@ class GuildLanguage(database.base):
 
     __tablename__ = "language_guilds"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    idx = Column(Integer, primary_key=True, autoincrement=True)
     guild_id = Column(BigInteger, unique=True)
     language = Column(String)
 
     def __repr__(self) -> str:
         return (
-            f'<GuildLanguage id="{self.id}" '
+            f'<GuildLanguage idx="{self.idx}" '
             f'guild_id="{self.guild_id}" language="{self.language}">'
         )
 
@@ -88,14 +88,14 @@ class MemberLanguage(database.base):
 
     __tablename__ = "language_members"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    idx = Column(Integer, primary_key=True, autoincrement=True)
     guild_id = Column(BigInteger)
     member_id = Column(BigInteger)
     language = Column(String)
 
     def __repr__(self) -> str:
         return (
-            f'<MemberLanguage id="{self.id}" guild_id="{self.guild_id}" '
+            f'<MemberLanguage idx="{self.idx}" guild_id="{self.guild_id}" '
             f'member_id="{self.member_id}" language="{self.language}">'
         )
 

--- a/database/logging.py
+++ b/database/logging.py
@@ -57,7 +57,7 @@ class Logging(database.base):
 
     __tablename__ = "logging"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    idx = Column(Integer, primary_key=True, autoincrement=True)
     guild_id = Column(BigInteger)
     channel_id = Column(BigInteger)
     scope = Column(String)  # "bot" or "guild"
@@ -231,7 +231,7 @@ class Logging(database.base):
     def __repr__(self) -> str:
         """Get object representation."""
         return (
-            f'<Logging id="{self.id}" '
+            f'<Logging idx="{self.idx}" '
             f'guild_id="{self.guild_id}" channel_id="{self.channel_id}" '
             f'level="{self.level} scope="{self.scope}" module="{self.module}">'
         )

--- a/docs/development/repository.rst
+++ b/docs/development/repository.rst
@@ -176,3 +176,10 @@ An example database file ``bistro/database.py`` may look like this:
 	    	    "name": self.name,
 	    	    "description": self.description,
 	    	}
+
+Testing
+-------
+
+You MAY include a directory called `tests/` in the root of the repository (e.g. between the module directories). This directory will be ignored by pumpkin.py module checks and won't emit "Invalid module" warnings.
+
+Please note that this may be changed in the future and some pumpkin.py versions may require the modules to be subclassed in `modules/` directory, if this proves to be confusing.

--- a/modules/base/acl/module.py
+++ b/modules/base/acl/module.py
@@ -193,8 +193,8 @@ class ACL(commands.Cog):
         await utils.Discord.send_help(ctx)
 
     @commands.check(acl.check)
-    @acl_rule.command(name="generate")
-    async def acl_rule_generate(self, ctx):
+    @acl_rule.command(name="template")
+    async def acl_rule_template(self, ctx):
         """Generate rule template."""
         filename: str = f"acl_{ctx.guild.id}_template.json"
 

--- a/modules/base/acl/module.py
+++ b/modules/base/acl/module.py
@@ -231,7 +231,7 @@ class ACL(commands.Cog):
 
         for rule in rules:
             rule_dict = rule.dump()
-            del rule_dict["id"]
+            del rule_dict["idx"]
             del rule_dict["command"]
             del rule_dict["guild_id"]
             export[rule.command] = rule_dict

--- a/modules/base/admin/module.py
+++ b/modules/base/admin/module.py
@@ -169,7 +169,8 @@ class Admin(commands.Cog):
         workdir = os.path.join(tempdir.name, "newmodule")
 
         # download to temporary directory
-        download_stderr = Admin._download_repository(url=url, path=tempdir.name)
+        async with ctx.typing():
+            download_stderr = Admin._download_repository(url=url, path=tempdir.name)
         if download_stderr is not None:
             tempdir.cleanup()
             if "does not exist" in download_stderr:
@@ -502,6 +503,8 @@ class Admin(commands.Cog):
         if key == "prefix":
             config.prefix = value
         elif key == "mention_as_prefix":
+            # FIXME This requires you to to know the internal implementation.
+            # We should hint it somewhere or change the key.
             config.mention_as_prefix = bool_value
         elif key == "language":
             config.language = value

--- a/modules/base/admin/module.py
+++ b/modules/base/admin/module.py
@@ -126,7 +126,7 @@ class Admin(commands.Cog):
                 repositories.append(repository)
             else:
                 # Do not raise warnings if it's just the Python stuff
-                if repository.directory == "__pycache__":
+                if repository.directory in ("tests", "__pycache__"):
                     continue
 
                 await bot_log.warning(

--- a/modules/base/base/database.py
+++ b/modules/base/base/database.py
@@ -10,7 +10,7 @@ from database import database, session
 class AutoPin(database.base):
     __tablename__ = "base_base_autopin"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    idx = Column(Integer, primary_key=True, autoincrement=True)
     guild_id = Column(BigInteger)
     channel_id = Column(BigInteger, default=None)
     limit = Column(Integer, default=0)
@@ -46,7 +46,7 @@ class AutoPin(database.base):
 
     def __repr__(self) -> str:
         return (
-            f"<AutoPin id='{self.id}' guild_id='{self.guild_id}' "
+            f"<AutoPin idx='{self.idx}' guild_id='{self.guild_id}' "
             f"channel_id='{self.channel_id}' limit='{self.limit}'>"
         )
 
@@ -61,7 +61,7 @@ class AutoPin(database.base):
 class AutoThread(database.base):
     __tablename__ = "base_base_autothread"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    idx = Column(Integer, primary_key=True, autoincrement=True)
     guild_id = Column(BigInteger)
     channel_id = Column(BigInteger, default=None)
     limit = Column(Integer, default=0)
@@ -97,7 +97,7 @@ class AutoThread(database.base):
 
     def __repr__(self) -> str:
         return (
-            f"<AutoThread id='{self.id}' guild_id='{self.guild_id}' "
+            f"<AutoThread idx='{self.idx}' guild_id='{self.guild_id}' "
             f"channel_id='{self.channel_id}' limit='{self.limit}'>"
         )
 
@@ -112,7 +112,7 @@ class AutoThread(database.base):
 class Bookmark(database.base):
     __tablename__ = "base_base_bookmarks"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    idx = Column(Integer, primary_key=True, autoincrement=True)
     guild_id = Column(BigInteger)
     channel_id = Column(BigInteger, default=None)
     enabled = Column(Boolean, default=False)
@@ -148,7 +148,7 @@ class Bookmark(database.base):
 
     def __repr__(self) -> str:
         return (
-            f"<Bookmark id='{self.id}' guild_id='{self.guild_id}' "
+            f"<Bookmark idx='{self.idx}' guild_id='{self.guild_id}' "
             f"channel_id='{self.channel_id}' enabled='{self.enabled}'>"
         )
 


### PR DESCRIPTION
- Use 'idx' instead of 'id' in database tables
- ACL: Rename command 'acl rule generate' to 'acl rule template'
- Admin: Ignore 'tests' directory in repository listing
- Admin: Use 'typing()' when cloning the repository 