### PR TITLE
Errors: Fix two cases of error handling

### DIFF
--- a/modules/base/errors/lang/cs.ini
+++ b/modules/base/errors/lang/cs.ini
@@ -159,7 +159,7 @@ value = Takové emoji jsem nenašla
 
 [ExpectedClosingQuoteError]
 name = Problém s uvozovkami
-value = Příkaz obsahuje neuzavřené uvozovky: `((char))`
+value = Příkaz obsahuje neuzavřené uvozovky.
 
 [ExtensionAlreadyLoaded]
 name = Chyba

--- a/modules/base/errors/lang/en.ini
+++ b/modules/base/errors/lang/en.ini
@@ -158,7 +158,7 @@ value = I don't know such emoji
 
 [ExpectedClosingQuoteError]
 name = Quotation problems
-value = The command contains unclosed quotation marks: `((char))`
+value = The command contains unclosed quotation marks.
 
 [ExtensionAlreadyLoaded]
 name = Error

--- a/modules/base/errors/module.py
+++ b/modules/base/errors/module.py
@@ -217,6 +217,12 @@ class Errors(commands.Cog):
                 tr("CommandRegistrationError", "value", ctx, cmd=error.name),
                 False,
             )
+        if isinstance(error, commands.UserInputError):
+            return (
+                tr(type(error).__name__, "name", ctx),
+                tr(type(error).__name__, "value", ctx),
+                False,
+            )
         if isinstance(error, commands.CommandError) or isinstance(
             error, discord.ClientException
         ):


### PR DESCRIPTION
- ExpectedClosingQuoteError: Do not try to say which quote is wrong, just say some is. Probability of mixing multiple quotes is low, and in case of multiple arguments the type of quote won't say much either.
- UserInputError: Do not forward to log, don't report content to user.