### PR TITLE
docker-compose version rollback

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.6"
 
 services:
   db:


### PR DESCRIPTION
Rolled back the docker-compose version so that it can be run on older docker-compose